### PR TITLE
Fix a typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm i ngx-oc-component --save
 import {NgModule} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 import {AppComponent} from './app.component';
-import {OcModule} from 'ngx-oc-component/oc.module';
+import {OcModule} from 'ngx-oc-component/oc-module';
 
 @NgModule({
     imports: [BrowserModule, OcModule],


### PR DESCRIPTION
It should be `oc-module` instead of `oc.module` right?